### PR TITLE
Alpha

### DIFF
--- a/af/design.ipynb
+++ b/af/design.ipynb
@@ -191,7 +191,7 @@
         "model.design(50, soft=True)\n",
         "\n",
         "# three stage design  \n",
-        "model.restart(seq_init=model._outs[\"seq_pseudo\"], keep_history=True)\n",
+        "model.restart(seq_init=model._outs[\"seq\"][\"pseudo\"], keep_history=True)\n",
         "model.design_3stage(50,50,10)"
       ],
       "metadata": {

--- a/af/examples/hallucination.ipynb
+++ b/af/examples/hallucination.ipynb
@@ -91,7 +91,7 @@
         "model.design(50, soft=True)\n",
         "\n",
         "# three stage design  \n",
-        "model.restart(seq_init=model._outs[\"seq_pseudo\"], keep_history=True)\n",
+        "model.restart(seq_init=model._outs[\"seq\"][\"pseudo\"], keep_history=True)\n",
         "model.design_3stage(50,50,10)"
       ],
       "metadata": {

--- a/af/src/init.py
+++ b/af/src/init.py
@@ -135,7 +135,8 @@ class _af_init:
     self._redesign = binder_chain is not None
     self._copies = 1
     self._repeat = False
-    self.args["use_binder_template"] = use_binder_template
+    if not use_binder_template:
+      self._default_opt["template_dropout"] = 1.0
 
     # get pdb info
     chains = f"{chain},{binder_chain}" if self._redesign else chain
@@ -149,7 +150,6 @@ class _af_init:
       self._inputs = self._prep_features(target_len)
       
     self._inputs["residue_index"][...,:] = pdb["residue_index"]
-
 
     # gather hotspot info
     if hotspot is None:

--- a/af/src/init.py
+++ b/af/src/init.py
@@ -303,11 +303,26 @@ def make_fixed_size(feat, model_runner, length, batch_axis=True):
       feat[k].set_shape(pad_size)
   return {k:np.asarray(v) for k,v in feat.items()}
 
+MODRES = {'MSE':'MET','MLY':'LYS','FME':'MET','HYP':'PRO',
+          'TPO':'THR','CSO':'CYS','SEP':'SER','M3L':'LYS',
+          'HSK':'HIS','SAC':'SER','PCA':'GLU','DAL':'ALA',
+          'CME':'CYS','CSD':'CYS','OCS':'CYS','DPR':'PRO',
+          'B3K':'LYS','ALY':'LYS','YCM':'CYS','MLZ':'LYS',
+          '4BF':'TYR','KCX':'LYS','B3E':'GLU','B3D':'ASP',
+          'HZP':'PRO','CSX':'CYS','BAL':'ALA','HIC':'HIS',
+          'DBZ':'ALA','DCY':'CYS','DVA':'VAL','NLE':'LEU',
+          'SMC':'CYS','AGM':'ARG','B3A':'ALA','DAS':'ASP',
+          'DLY':'LYS','DSN':'SER','DTH':'THR','GL3':'GLY',
+          'HY3':'PRO','LLP':'LYS','MGN':'GLN','MHS':'HIS',
+          'TRQ':'TRP','B3Y':'TYR','PHI':'PHE','PTR':'TYR',
+          'TYS':'TYR','IAS':'ASP','GPL':'LYS','KYN':'TRP',
+          'CSD':'CYS','SEC':'CYS'}
+
 def pdb_to_string(pdb_file):
   lines = []
   for line in open(pdb_file,"r"):
-    if line[:6] == "HETATM" and line[17:20] == "MSE":
-      line = "ATOM  "+line[6:17]+"MET"+line[20:]
+    if line[:6] == "HETATM" and line[17:20] in MODRES:
+      line = "ATOM  "+line[6:17]+MODRES[line[17:20]]+line[20:]
     if line[:4] == "ATOM":
       lines.append(line)
   return "".join(lines)

--- a/af/src/init.py
+++ b/af/src/init.py
@@ -133,6 +133,9 @@ class _af_init:
     '''prep inputs for binder design'''
     
     self._redesign = binder_chain is not None
+    self._copies = 1
+    self._repeat = False
+    self.args["use_binder_template"] = use_binder_template
 
     # get pdb info
     chains = f"{chain},{binder_chain}" if self._redesign else chain
@@ -147,8 +150,6 @@ class _af_init:
       
     self._inputs["residue_index"][...,:] = pdb["residue_index"]
 
-    self._copies = 1
-    self._repeat = False
 
     # gather hotspot info
     if hotspot is None:

--- a/af/src/init.py
+++ b/af/src/init.py
@@ -58,7 +58,7 @@ class _af_init:
                'all_atom_positions': protein_obj.atom_positions,
                'all_atom_mask': protein_obj.atom_mask}
             
-      add_cb(batch) # add in missing cb (in the case of glycine)
+      #add_cb(batch) # add in missing cb (in the case of glycine)
 
       has_ca = batch["all_atom_mask"][:,0] == 1
       batch = jax.tree_map(lambda x:x[has_ca], batch)

--- a/af/src/init.py
+++ b/af/src/init.py
@@ -158,7 +158,8 @@ class _af_init:
       
       self._batch = pdb["batch"]
       self._wt_aatype = self._batch["aatype"][target_len:]
-      self._default_weights.update({"dgram_cce":1.0, "fape":0.0, "rmsd":0.0, "con":0.0})
+      self._default_weights.update({"dgram_cce":1.0, "fape":0.0, "rmsd":0.0,
+                                    "con":0.0, "i_pae":0.0, "i_con":0.0})
       
     else: # binder hallucination
             

--- a/af/src/init.py
+++ b/af/src/init.py
@@ -30,9 +30,9 @@ class _af_init:
     }
     if template_features is not None: feature_dict.update(template_features)    
     inputs = self._runner.process_features(feature_dict, random_seed=0)
-    if num_seq > 1:
-      inputs["msa_row_mask"] = jnp.ones_like(inputs["msa_row_mask"])
-      inputs["msa_mask"] = jnp.ones_like(inputs["msa_mask"])
+    #if num_seq > 1:
+    #  inputs["msa_row_mask"] = jnp.ones_like(inputs["msa_row_mask"])
+    #  inputs["msa_mask"] = jnp.ones_like(inputs["msa_mask"])
     return inputs
 
   def _prep_pdb(self, pdb_filename, chain=None):

--- a/af/src/init.py
+++ b/af/src/init.py
@@ -282,7 +282,7 @@ def make_fixed_size(feat, model_runner, length, batch_axis=True):
   else:
     shape_schema = {k:v for k,v in dict(cfg.data.eval.feat).items()}
 
-  num_msa_seq = cfg.data.eval.max_msa_clusters #- cfg.data.eval.max_templates
+  num_msa_seq = cfg.data.eval.max_msa_clusters - cfg.data.eval.max_templates
   pad_size_map = {
       shape_placeholders.NUM_RES: length,
       shape_placeholders.NUM_MSA_SEQ: num_msa_seq,

--- a/af/src/init.py
+++ b/af/src/init.py
@@ -154,8 +154,9 @@ class _af_init:
       self._inputs["template_all_atom_masks"][...,target_len:,5:] = 0
       if not use_binder_template:
         self._inputs["template_all_atom_masks"][...,target_len:,:] = 0
-        self._inputs["template_pseudo_beta_mask"][...,target_len:] = 0
+        self._inputs["template_pseudo_beta_mask"][...,target_len:] = 0      
       
+      self._batch = pdb["batch"]
       self._default_weights.update({"dgram_cce":1.0, "fape":0.0, "rmsd":0.0, "con":0.0})
       
     else: # binder hallucination

--- a/af/src/init.py
+++ b/af/src/init.py
@@ -30,9 +30,9 @@ class _af_init:
     }
     if template_features is not None: feature_dict.update(template_features)    
     inputs = self._runner.process_features(feature_dict, random_seed=0)
-    #if num_seq > 1:
-    #  inputs["msa_row_mask"] = jnp.ones_like(inputs["msa_row_mask"])
-    #  inputs["msa_mask"] = jnp.ones_like(inputs["msa_mask"])
+    if num_seq > 1:
+      inputs["msa_row_mask"] = jnp.ones_like(inputs["msa_row_mask"])
+      inputs["msa_mask"] = jnp.ones_like(inputs["msa_mask"])
     return inputs
 
   def _prep_pdb(self, pdb_filename, chain=None):

--- a/af/src/init.py
+++ b/af/src/init.py
@@ -159,7 +159,7 @@ class _af_init:
       self._batch = pdb["batch"]
       self._wt_aatype = self._batch["aatype"][target_len:]
       self._default_weights.update({"dgram_cce":1.0, "fape":0.0, "rmsd":0.0,
-                                    "con":0.0, "i_pae":0.0, "i_con":0.0})
+                                    "con":0.0, "i_pae":0.01, "i_con":0.0})
       
     else: # binder hallucination
             

--- a/af/src/init.py
+++ b/af/src/init.py
@@ -282,7 +282,7 @@ def make_fixed_size(feat, model_runner, length, batch_axis=True):
 
   pad_size_map = {
       shape_placeholders.NUM_RES: length,
-      shape_placeholders.NUM_MSA_SEQ: cfg.data.eval.max_msa_clusters,
+      shape_placeholders.NUM_MSA_SEQ: 1,
       shape_placeholders.NUM_EXTRA_SEQ: cfg.data.common.max_extra_msa,
       shape_placeholders.NUM_TEMPLATES: cfg.data.eval.max_templates
   }

--- a/af/src/init.py
+++ b/af/src/init.py
@@ -185,7 +185,11 @@ class _af_init:
     self._batch = pdb["batch"]
     self._wt_aatype = self._batch["aatype"]
     self._len = pdb["residue_index"].shape[0]
-    self._inputs = self._prep_features(self._len, pdb["template_features"])
+    temp_features = {'template_aatype': np.zeros([1,self._len,22]),
+                     'template_all_atom_masks': np.zeros([1,self._len,37]),
+                     'template_all_atom_positions': np.zeros([1,self._len,37,3]),
+                     'template_domain_names': np.asarray(["None"])}
+    self._inputs = self._prep_features(self._len, temp_features)
     self._copies = copies
     self._repeat = repeat
     
@@ -259,9 +263,6 @@ class _af_init:
                        'template_all_atom_positions': np.zeros([1,self._len,37,3]),
                        'template_domain_names': np.asarray(["None"])}
       self._inputs = self._prep_features(self._len, temp_features)
-      if fix_seq:
-        self._default_opt["template_aatype"] = self._batch["aatype"]
-
     else:
       self._inputs = self._prep_features(self._len)
     

--- a/af/src/init.py
+++ b/af/src/init.py
@@ -282,9 +282,10 @@ def make_fixed_size(feat, model_runner, length, batch_axis=True):
   else:
     shape_schema = {k:v for k,v in dict(cfg.data.eval.feat).items()}
 
+  num_msa_seq = cfg.data.eval.max_msa_clusters - cfg.data.eval.max_templates
   pad_size_map = {
       shape_placeholders.NUM_RES: length,
-      shape_placeholders.NUM_MSA_SEQ: 1,
+      shape_placeholders.NUM_MSA_SEQ: num_msa_seq,
       shape_placeholders.NUM_EXTRA_SEQ: cfg.data.common.max_extra_msa,
       shape_placeholders.NUM_TEMPLATES: cfg.data.eval.max_templates
   }

--- a/af/src/init.py
+++ b/af/src/init.py
@@ -58,7 +58,7 @@ class _af_init:
                'all_atom_positions': protein_obj.atom_positions,
                'all_atom_mask': protein_obj.atom_mask}
             
-      #add_cb(batch) # add in missing cb (in the case of glycine)
+      add_cb(batch) # add in missing cb (in the case of glycine)
 
       has_ca = batch["all_atom_mask"][:,0] == 1
       batch = jax.tree_map(lambda x:x[has_ca], batch)

--- a/af/src/init.py
+++ b/af/src/init.py
@@ -282,7 +282,7 @@ def make_fixed_size(feat, model_runner, length, batch_axis=True):
   else:
     shape_schema = {k:v for k,v in dict(cfg.data.eval.feat).items()}
 
-  num_msa_seq = cfg.data.eval.max_msa_clusters - cfg.data.eval.max_templates
+  num_msa_seq = cfg.data.eval.max_msa_clusters #- cfg.data.eval.max_templates
   pad_size_map = {
       shape_placeholders.NUM_RES: length,
       shape_placeholders.NUM_MSA_SEQ: num_msa_seq,

--- a/af/src/init.py
+++ b/af/src/init.py
@@ -157,6 +157,7 @@ class _af_init:
         self._inputs["template_pseudo_beta_mask"][...,target_len:] = 0      
       
       self._batch = pdb["batch"]
+      self._wt_aatype = self._batch["aatype"][target_len:]
       self._default_weights.update({"dgram_cce":1.0, "fape":0.0, "rmsd":0.0, "con":0.0})
       
     else: # binder hallucination

--- a/af/src/init.py
+++ b/af/src/init.py
@@ -120,8 +120,7 @@ class _af_init:
   
   # prep functions specific to protocol
   def _prep_binder(self, pdb_filename, chain="A",
-                   binder_len=50, binder_chain=None,
-                   use_binder_template=False,
+                   binder_len=50, binder_chain=None, use_binder_template=False,
                    hotspot=None, **kwargs):
 
     '''prep inputs for binder design'''
@@ -156,7 +155,9 @@ class _af_init:
       if not use_binder_template:
         self._inputs["template_all_atom_masks"][...,target_len:,:] = 0
         self._inputs["template_pseudo_beta_mask"][...,target_len:] = 0
-
+      
+      self._default_weights.update({"dgram_cce":1.0, "fape":0.0, "rmsd":0.0, "con":0.0})
+      
     else: # binder hallucination
             
       # pad inputs

--- a/af/src/loss.py
+++ b/af/src/loss.py
@@ -301,7 +301,9 @@ class _af_loss:
                T+"all_atom_masks": self._batch["all_atom_mask"],
                T+"pseudo_beta": pb, T+"pseudo_beta_mask": pb_mask}
       
-      if self.protocol == "fixbb": inputs.update(feats)
+      if self.protocol == "fixbb":
+        for k,v in feats.items():
+          inputs[k] = inputs[k].at[:].set(v)
       else:
         p = opt["pos"]      
         for k,v in feats.items():

--- a/af/src/loss.py
+++ b/af/src/loss.py
@@ -69,7 +69,7 @@ class _af_loss:
       update_aatype(jnp.broadcast_to(aatype,(B,L,21)), inputs)
       
       # MAGIC
-      inputs["msa_feat"] = jnp.pad(inputs["msa_feat"],[[0,0],[0,1],[0,0],[0,0]])
+      inputs["msa_feat"] = inputs["msa_feat"].at[:,-1].set(0.0)
 
       # update template features
       if self.args["use_templates"]:

--- a/af/src/loss.py
+++ b/af/src/loss.py
@@ -296,7 +296,7 @@ class _af_loss:
       pb, pb_mask = model.modules.pseudo_beta_fn(jnp.zeros(L),
                                                  self._batch["all_atom_positions"],
                                                  self._batch["all_atom_mask"])
-      feats = {T+"aatype": jnp.full(L,21),
+      feats = {T+"aatype": jnp.broadcast_to(opt[T+"aatype"],(L,)),
                T+"all_atom_positions": self._batch["all_atom_positions"],
                T+"all_atom_masks": self._batch["all_atom_mask"],
                T+"pseudo_beta": pb, T+"pseudo_beta_mask": pb_mask}
@@ -312,6 +312,8 @@ class _af_loss:
           else:
             if k == "template_aatype": v = jax.nn.one_hot(v,22)
             inputs[k] = jnp.einsum("ij,i...->j...",p,v)[None,None]
+            
+      inputs[T+"all_atom_masks"] = inputs[T+"all_atom_masks"].at[...,5:].set(0)
               
     # dropout template input features
     L = self._len

--- a/af/src/loss.py
+++ b/af/src/loss.py
@@ -292,8 +292,8 @@ class _af_loss:
     ''''dynamically update template features'''
     T = "template_"    
     if self.protocol in ["partial","fixbb","binder"]:
-      L = self._batch["aatype"].shape[0]
       
+      L = self._batch["aatype"].shape[0]
       if self.protocol in ["partial","fixbb"]:
         aatype = jnp.zeros(L)
         template_aatype = jnp.broadcast_to(opt[T+"aatype"],(L,))
@@ -335,8 +335,8 @@ class _af_loss:
         inputs[T+"all_atom_masks"] = inputs[T+"all_atom_masks"].at[...,self._target_len:,5:].set(0)
 
     # dropout template input features
-    L = self._len
+    L = inputs[T+"aatype"].shape[2]
     s = self._target_len if self.protocol == "binder" else 0
     pos_mask = jax.random.bernoulli(key, 1-opt[T+"dropout"],(L,))
-    inputs[T+"all_atom_masks"] = inputs[T+"all_atom_masks"].at[...,s:,:].multiply(pos_mask[s:,None])
-    inputs[T+"pseudo_beta_mask"] = inputs[T+"pseudo_beta_mask"].at[...,s:].multiply(pos_mask[s:])
+    inputs[T+"all_atom_masks"] = inputs[T+"all_atom_masks"].at[:,:,s:].multiply(pos_mask[s:,None])
+    inputs[T+"pseudo_beta_mask"] = inputs[T+"pseudo_beta_mask"].at[:,:,s:].multiply(pos_mask[s:])

--- a/af/src/loss.py
+++ b/af/src/loss.py
@@ -56,7 +56,7 @@ class _af_loss:
         seq_target = jax.nn.one_hot(self._batch["aatype"][:self._target_len],20)
         seq_target = jnp.broadcast_to(seq_target,(self.args["num_seq"],*seq_target.shape))
         seq_pseudo = jnp.concatenate([seq_target, seq_pseudo], 1)
-        if self.args["use_templates"]:
+        if self.args["use_templates"] and not self._redesign:
           seq_pseudo = jnp.pad(seq_pseudo,[[0,1],[0,0],[0,0]])
       
       if self.protocol in ["fixbb","hallucination"] and self._copies > 1:

--- a/af/src/loss.py
+++ b/af/src/loss.py
@@ -267,7 +267,7 @@ class _af_loss:
     c,ic = opt["con"],opt["i_con"]
     
     # if more than 1 chain, split pae/con into inter/intra
-    if (self.protocol == binder and not self._redesign) or (self._copies > 1 and not self._repeat):
+    if (self.protocol == "binder" and not self._redesign) or (self._copies > 1 and not self._repeat):
       aux["pae"] = get_pae(outputs)
 
       L = self._target_len if self.protocol == "binder" else self._len

--- a/af/src/loss.py
+++ b/af/src/loss.py
@@ -56,14 +56,7 @@ class _af_loss:
         seq_target = jax.nn.one_hot(self._batch["aatype"][:self._target_len],20)
         seq_target = jnp.broadcast_to(seq_target,(self.args["num_seq"],*seq_target.shape))
         seq_pseudo = jnp.concatenate([seq_target, seq_pseudo], 1)
-        
-        #############################
-        # MAGIC
-        #############################
-        if self.args["use_templates"]:
-          seq_pseudo = jnp.pad(seq_pseudo,[[0,1],[0,0],[0,0]])
-        #############################
-      
+              
       if self.protocol in ["fixbb","hallucination"] and self._copies > 1:
         seq_pseudo = jnp.concatenate([seq_pseudo]*self._copies, 1)
             

--- a/af/src/loss.py
+++ b/af/src/loss.py
@@ -296,6 +296,7 @@ class _af_loss:
       pb, pb_mask = model.modules.pseudo_beta_fn(jnp.zeros(L),
                                                  self._batch["all_atom_positions"],
                                                  self._batch["all_atom_mask"])
+      
       feats = {T+"aatype": jnp.broadcast_to(opt[T+"aatype"],(L,)),
                T+"all_atom_positions": self._batch["all_atom_positions"],
                T+"all_atom_masks": self._batch["all_atom_mask"],

--- a/af/src/loss.py
+++ b/af/src/loss.py
@@ -67,6 +67,9 @@ class _af_loss:
       B,L = inputs["aatype"].shape[:2]
       aatype = jax.nn.one_hot(seq_pseudo[0].argmax(-1),21)
       update_aatype(jnp.broadcast_to(aatype,(B,L,21)), inputs)
+      
+      # MAGIC
+      inputs["msa_feat"] = jnp.pad(inputs["msa_feat"],[[0,0],[0,1],[0,0],[0,0]])
 
       # update template features
       if self.args["use_templates"]:

--- a/af/src/loss.py
+++ b/af/src/loss.py
@@ -50,7 +50,7 @@ class _af_loss:
           seq = jax.tree_map(lambda x:x*w + seq_ref, seq)
 
       # save for aux output
-      aux = {"seq":seq}
+      aux = {"seq":seq, "seq_pseudo":seq["pseudo"]}
 
       # entropy loss for msa
       if self.args["num_seq"] > 1:

--- a/af/src/loss.py
+++ b/af/src/loss.py
@@ -293,7 +293,7 @@ class _af_loss:
           x, ix = get_con_loss(x, c, x_offset), get_con_loss(ix, ic, ix_offset)
         losses.update({k:x.mean(),f"i_{k}":ix.mean()})
     else:
-      if self.protocol == binder: aux["pae"] = get_pae(outputs)
+      if self.protocol == "binder": aux["pae"] = get_pae(outputs)
       losses.update({"con":get_con_loss(dgram, c, offset).mean(),
                      "helix":get_helix_loss(dgram, c, offset),
                      "pae":pae.mean()})

--- a/af/src/loss.py
+++ b/af/src/loss.py
@@ -265,7 +265,7 @@ class _af_loss:
     c,ic = opt["con"],opt["i_con"]
     
     # if more than 1 chain, split pae/con into inter/intra
-    if (self.protocol == "binder" and not self._redesign) or (self._copies > 1 and not self._repeat):
+    if self.protocol == "binder" or (self._copies > 1 and not self._repeat):
       aux["pae"] = get_pae(outputs)
 
       L = self._target_len if self.protocol == "binder" else self._len

--- a/af/src/loss.py
+++ b/af/src/loss.py
@@ -56,8 +56,6 @@ class _af_loss:
         seq_target = jax.nn.one_hot(self._batch["aatype"][:self._target_len],20)
         seq_target = jnp.broadcast_to(seq_target,(self.args["num_seq"],*seq_target.shape))
         seq_pseudo = jnp.concatenate([seq_target, seq_pseudo], 1)
-        if self.args["use_templates"] and not self._redesign:
-          seq_pseudo = jnp.pad(seq_pseudo,[[0,1],[0,0],[0,0]])
       
       if self.protocol in ["fixbb","hallucination"] and self._copies > 1:
         seq_pseudo = jnp.concatenate([seq_pseudo]*self._copies, 1)

--- a/af/src/loss.py
+++ b/af/src/loss.py
@@ -316,10 +316,7 @@ class _af_loss:
       # protocol specific template masking      
       if self.protocol in ["fixbb","binder"]:
         for k,v in feats.items():
-          if self.protocol == "binder" and self.args["use_binder_template"]:
-            inputs[k] = inputs[k].at[:].set(v).at[:,:,self._target_len:].set(0)
-          else:
-            inputs[k] = inputs[k].at[:].set(v)            
+          inputs[k] = inputs[k].at[:].set(v)            
       else:
         p = opt["pos"]
         for k,v in feats.items():

--- a/af/src/loss.py
+++ b/af/src/loss.py
@@ -169,7 +169,7 @@ class _af_loss:
     L = self._len
     s = self._target_len if self.protocol == "binder" else 0
     pos_mask = jax.random.bernoulli(key, 1-opt[t+"dropout"],(L,))
-    inputs[t+"all_atom_masks"] = inputs[f+"all_atom_masks"].at[...,s:,:].multiply(pos_mask[s:,None])
+    inputs[t+"all_atom_masks"] = inputs[t+"all_atom_masks"].at[...,s:,:].multiply(pos_mask[s:,None])
     inputs[t+"pseudo_beta_mask"] = inputs[t+"pseudo_beta_mask"].at[...,s:].multiply(pos_mask[s:])
     
   def _get_partial_loss(self, outputs, opt, aatype=None):

--- a/af/src/loss.py
+++ b/af/src/loss.py
@@ -56,6 +56,13 @@ class _af_loss:
         seq_target = jax.nn.one_hot(self._batch["aatype"][:self._target_len],20)
         seq_target = jnp.broadcast_to(seq_target,(self.args["num_seq"],*seq_target.shape))
         seq_pseudo = jnp.concatenate([seq_target, seq_pseudo], 1)
+        
+        #############################
+        # MAGIC
+        #############################
+        if self.args["use_templates"]:
+          seq_pseudo = jnp.pad(seq_pseudo,[[0,1],[0,0],[0,0]])
+        #############################
       
       if self.protocol in ["fixbb","hallucination"] and self._copies > 1:
         seq_pseudo = jnp.concatenate([seq_pseudo]*self._copies, 1)
@@ -68,9 +75,6 @@ class _af_loss:
       aatype = jax.nn.one_hot(seq_pseudo[0].argmax(-1),21)
       update_aatype(jnp.broadcast_to(aatype,(B,L,21)), inputs)
       
-      # MAGIC
-      inputs["msa_feat"] = inputs["msa_feat"].at[:,-1].set(0.0)
-
       # update template features
       if self.args["use_templates"]:
 

--- a/af/src/loss.py
+++ b/af/src/loss.py
@@ -296,7 +296,7 @@ class _af_loss:
       pb, pb_mask = model.modules.pseudo_beta_fn(jnp.zeros(L),
                                                  self._batch["all_atom_positions"],
                                                  self._batch["all_atom_mask"])
-      feats = {T+"aatype": jax.nn.one_hot(jnp.full(L,21),22),
+      feats = {T+"aatype": jnp.full(L,21),
                T+"all_atom_positions": self._batch["all_atom_positions"],
                T+"all_atom_masks": self._batch["all_atom_mask"],
                T+"pseudo_beta": pb, T+"pseudo_beta_mask": pb_mask}
@@ -305,11 +305,12 @@ class _af_loss:
         for k,v in feats.items():
           inputs[k] = inputs[k].at[:].set(v)
       else:
-        p = opt["pos"]      
+        p = opt["pos"]
         for k,v in feats.items():
           if jnp.issubdtype(p.dtype, jnp.integer):
             inputs[k] = inputs[k].at[:,:,p].set(v)
           else:
+            if k == "template_aatype": v = jax.nn.one_hot(v,22)
             inputs[k] = jnp.einsum("ij,i...->j...",p,v)[None,None]
               
     # dropout template input features

--- a/af/src/loss.py
+++ b/af/src/loss.py
@@ -301,9 +301,7 @@ class _af_loss:
                T+"all_atom_masks": self._batch["all_atom_mask"],
                T+"pseudo_beta": pb, T+"pseudo_beta_mask": pb_mask}
       
-      if self.protocol == "fixbb":
-        inputs.update(feat)
-      
+      if self.protocol == "fixbb": inputs.update(feats)
       else:
         p = opt["pos"]      
         for k,v in feats.items():

--- a/af/src/loss.py
+++ b/af/src/loss.py
@@ -155,7 +155,7 @@ class _af_loss:
                t+"pseudo_beta": pb, t+"pseudo_beta_mask": pb_mask}
             
       p = opt["pos"]      
-      for k,v in template_feats.items():
+      for k,v in feats.items():
         if jnp.issubdtype(p.dtype, jnp.integer):
           inputs[k] = inputs[k].at[:,:,p].set(v)
         else:

--- a/af/src/loss.py
+++ b/af/src/loss.py
@@ -131,7 +131,7 @@ class _af_loss:
       else:
         losses["plddt"] = plddt_loss.mean()
 
-      if self.protocol == "fixbb":
+      if self.protocol == "fixbb" or (self.protocol == "binder" and self._redesign):
         o = self._get_fixbb_loss(outputs, opt, aatype=aatype)
         losses.update(o["losses"]); aux.update(o["aux"])
 
@@ -267,7 +267,7 @@ class _af_loss:
     c,ic = opt["con"],opt["i_con"]
     
     # if more than 1 chain, split pae/con into inter/intra
-    if self.protocol in ["binder"] or (self._copies > 1 and not self._repeat):
+    if (self.protocol == binder and not self._redesign) or (self._copies > 1 and not self._repeat):
       aux["pae"] = get_pae(outputs)
 
       L = self._target_len if self.protocol == "binder" else self._len
@@ -293,6 +293,7 @@ class _af_loss:
           x, ix = get_con_loss(x, c, x_offset), get_con_loss(ix, ic, ix_offset)
         losses.update({k:x.mean(),f"i_{k}":ix.mean()})
     else:
+      if self.protocol == binder: aux["pae"] = get_pae(outputs)
       losses.update({"con":get_con_loss(dgram, c, offset).mean(),
                      "helix":get_helix_loss(dgram, c, offset),
                      "pae":pae.mean()})

--- a/af/src/loss.py
+++ b/af/src/loss.py
@@ -20,52 +20,59 @@ class _af_loss:
       losses = {}
 
       # set sequence
-      seq = params["seq"]
+      seq = {"input":params["seq"]}
+      seq_shape = params["seq"].shape
 
       # shuffle msa (randomly pick which sequence is query)
       if self.args["num_seq"] > 1:
-        i = jax.random.randint(key,[],0,seq.shape[0])
-        seq = seq.at[0].set(seq[i]).at[i].set(seq[0])
+        n = jax.random.randint(key,[],0,seq_shape[0])
+        seq["input"] = seq["input"].at[0].set(seq["input"][n]).at[n].set(seq["input"][0])
 
       # straight-through/reparameterization
-      seq_logits = 2.0 * seq + opt["bias"] + jnp.where(opt["gumbel"], jax.random.gumbel(key,seq.shape), 0.0)
-      seq_soft = jax.nn.softmax(seq_logits / opt["temp"])
-      seq_hard = jax.nn.one_hot(seq_soft.argmax(-1), 20)
-      seq_hard = jax.lax.stop_gradient(seq_hard - seq_soft) + seq_soft
+      seq["logits"] = 2.0 * seq["input"] + opt["bias"] + jnp.where(opt["gumbel"], jax.random.gumbel(key,seq_shape), 0.0)
+      seq["soft"] = jax.nn.softmax(seq["logits"] / opt["temp"])
+      seq["hard"] = jax.nn.one_hot(seq["soft"].argmax(-1), 20)
+      seq["hard"] = jax.lax.stop_gradient(seq["hard"] - seq["soft"]) + seq["soft"]
 
       # create pseudo sequence
-      seq_pseudo = opt["soft"] * seq_soft + (1-opt["soft"]) * seq
-      seq_pseudo = opt["hard"] * seq_hard + (1-opt["hard"]) * seq_pseudo
+      seq["pseudo"] = opt["soft"] * seq["soft"] + (1-opt["soft"]) * seq["input"]
+      seq["pseudo"] = opt["hard"] * seq["hard"] + (1-opt["hard"]) * seq["pseudo"]
 
       # for partial hallucination, force sequence if sidechain constraints defined
       if self.protocol == "partial" and (self.args["fix_seq"] or self.args["sidechain"]):
+        p = opt["pos"]
         seq_ref = jax.nn.one_hot(self._wt_aatype,20)
-        seq_pseudo = seq_pseudo.at[:,opt["pos"],:].set(seq_ref)
-        seq_hard = seq_hard.at[:,opt["pos"],:].set(seq_ref)
+        if jnp.issubdtype(p.dtype, jnp.integer):
+          seq = jax.tree_map(lambda x:x.at[:,p,:].set(seq_ref), seq)
+        else:
+          seq_ref = p.T @ seq_ref
+          w = 1 - seq_ref.sum(-1, keepdims=True)
+          seq = jax.tree_map(lambda x:x*w + seq_ref, seq)
 
       # save for aux output
-      aux = {"seq":seq_hard,"seq_pseudo":seq_pseudo}
+      aux = {"seq":seq}
 
       # entropy loss for msa
       if self.args["num_seq"] > 1:
-        seq_prf = seq_hard.mean(0)
+        seq_prf = seq["hard"].mean(0)
         losses["msa_ent"] = -(seq_prf * jnp.log(seq_prf + 1e-8)).sum(-1).mean()
-      
+        
       if self.protocol == "binder":
         # concatenate target and binder sequence
         seq_target = jax.nn.one_hot(self._batch["aatype"][:self._target_len],20)
         seq_target = jnp.broadcast_to(seq_target,(self.args["num_seq"],*seq_target.shape))
-        seq_pseudo = jnp.concatenate([seq_target, seq_pseudo], 1)
+        seq = jax.tree_map(lambda x:jnp.concatenate([seq_target,x],1), seq)
               
       if self.protocol in ["fixbb","hallucination"] and self._copies > 1:
-        seq_pseudo = jnp.concatenate([seq_pseudo]*self._copies, 1)
+        seq = jax.tree_map(lambda x:jnp.concatenate([x]*self._copies,1), seq)
             
       # update sequence
-      update_seq(seq_pseudo, inputs)
+      seq_pssm = seq["soft"] if self.args["use_pssm"] else None
+      update_seq(seq["pseudo"], inputs, seq_pssm=seq_pssm)
       
       # update amino acid sidechain identity
       B,L = inputs["aatype"].shape[:2]
-      aatype = jax.nn.one_hot(seq_pseudo[0].argmax(-1),21)
+      aatype = jax.nn.one_hot(seq["pseudo"][0].argmax(-1),21)
       update_aatype(jnp.broadcast_to(aatype,(B,L,21)), inputs)
       
       # update template features

--- a/af/src/model.py
+++ b/af/src/model.py
@@ -18,7 +18,7 @@ class mk_design_model(_af_init, _af_loss, _af_design, _af_utils):
                num_models=1, model_mode="sample", model_parallel=False,
                num_recycles=0, recycle_mode="average",
                use_templates=False, use_template_tor=True,
-               data_dir="."):
+               use_pssm=False, data_dir="."):
 
     # decide if templates should be used
     if protocol == "binder": use_templates = True

--- a/af/src/model.py
+++ b/af/src/model.py
@@ -27,7 +27,7 @@ class mk_design_model(_af_init, _af_loss, _af_design, _af_utils):
     
     self.args = {"num_seq":num_seq, "use_templates":use_templates,
                  "model_mode":model_mode, "model_parallel": model_parallel,
-                 "recycle_mode":recycle_mode}
+                 "recycle_mode":recycle_mode, "use_pssm":use_pssm}
     
     self._default_opt = {"temp":1.0, "soft":0.0, "hard":0.0,"gumbel":False,
                          "dropout":True, "dropout_scale":1.0,

--- a/af/src/model.py
+++ b/af/src/model.py
@@ -34,7 +34,7 @@ class mk_design_model(_af_init, _af_loss, _af_design, _af_utils):
                          "recycles":num_recycles, "models":num_models,
                          "con":  {"num":2, "cutoff":14.0, "seqsep":9, "binary":False, "entropy":True},
                          "i_con":{"num":1, "cutoff":20.0,             "binary":False, "entropy":True},
-                         "bias":np.zeros(20), "template_aatype":21, "template_dropout":0.0}
+                         "bias":np.zeros(20), "template_aatype":21, "template_dropout":0.15}
 
     self._default_weights = {"msa_ent":0.0, "helix":0.0, "plddt":0.01, "pae":0.01}
 

--- a/af/src/utils.py
+++ b/af/src/utils.py
@@ -64,7 +64,7 @@ class _af_utils:
 
     # save trajectory
     ca_xyz = self._outs["final_atom_positions"][:,1,:]
-    traj = {"xyz":ca_xyz,"plddt":self._outs["plddt"],"seq":self._outs["seq_pseudo"]}
+    traj = {"xyz":ca_xyz,"plddt":self._outs["plddt"],"seq":self._outs["seq"]["pseudo"]}
     if "pae" in self._outs: traj.update({"pae":self._outs["pae"]})
     for k,v in traj.items(): self._traj[k].append(np.array(v))
 

--- a/af/src/utils.py
+++ b/af/src/utils.py
@@ -34,7 +34,7 @@ class _af_utils:
     self._losses.update({"model":self._model_num,"loss":self._loss, 
                         **{k:self.opt[k] for k in ["soft","hard","temp"]}})
     
-    if self.protocol == "fixbb":
+    if self.protocol == "fixbb" or (self.protocol == "binder" and self._redesign):
       # compute sequence recovery
       _aatype = self._outs["seq"].argmax(-1)
       L = min(_aatype.shape[-1], self._wt_aatype.shape[-1])
@@ -144,7 +144,7 @@ class _af_utils:
     ax2 = fig.add_subplot(gs[3:,:])
     ax1_ = ax1.twinx()
     
-    if self.protocol == "fixbb":
+    if self.protocol == "fixbb" or (self.protocol == "binder" and self._redesign):
       rmsd = self.get_loss("rmsd")
       for k in [0.5,1,2,4,8,16,32]:
         ax1.plot([0,len(rmsd)],[k,k],color="lightgrey")

--- a/af/src/utils.py
+++ b/af/src/utils.py
@@ -36,7 +36,7 @@ class _af_utils:
     
     if self.protocol == "fixbb" or (self.protocol == "binder" and self._redesign):
       # compute sequence recovery
-      _aatype = self._outs["seq"].argmax(-1)
+      _aatype = self._outs["seq"]["hard"].argmax(-1)
       L = min(_aatype.shape[-1], self._wt_aatype.shape[-1])
       self._losses["seqid"] = (_aatype[...,:L] == self._wt_aatype[...,:L]).mean()
 

--- a/af/src/utils.py
+++ b/af/src/utils.py
@@ -71,7 +71,7 @@ class _af_utils:
   def get_seqs(self):
     outs = self._outs if self._best_outs is None else self._best_outs
     outs = jax.tree_map(lambda x:np.asarray(x), outs)
-    x = np.array(outs["seq"]).argmax(-1)
+    x = outs["seq"]["hard"].argmax(-1)
     return ["".join([order_restype[a] for a in s]) for s in x]
   
   def get_loss(self, x="loss"):

--- a/af/src/utils.py
+++ b/af/src/utils.py
@@ -82,7 +82,7 @@ class _af_utils:
     '''save pdb coordinates'''
     outs = self._outs if self._best_outs is None else self._best_outs
     outs = jax.tree_map(lambda x:np.asarray(x), outs)
-    aatype = outs["seq"].argmax(-1)[0]
+    aatype = outs["seq"]["hard"].argmax(-1)[0]
     if self.protocol == "binder":
       aatype_target = self._batch["aatype"][:self._target_len]
       aatype = np.concatenate([aatype_target,aatype])


### PR DESCRIPTION
-refactored all the template code (inputs are blanked, and dynamically filled in later)
-adding support for binder redesign (instead of just hallucination).
-pseudo-Cb distrogram ground truth now aatype depended (in case of glycine, Ca is used, otherwise Cb), before it was fixed to whatever natural protein was
-adding support for modified amino acids, before they were excluded
-for partial hallucination, adding support for defining positions using matrix instead of index (will be useful later when we make positions differentiable)
-fix make_fixed_size(), before a blank sequence was being added
-adding support for repeat protein design/hallucination