### PR TITLE
Update af_cyc_design.ipynb

### DIFF
--- a/af/examples/af_cyc_design.ipynb
+++ b/af/examples/af_cyc_design.ipynb
@@ -16,7 +16,7 @@
         "id": "OA2k3sAYuiXe"
       },
       "source": [
-        "#af_cys_design\n",
+        "#af_cyc_design\n",
         "\n",
         "**Cyclic peptide structure prediction and design using AlphaFold**\n",
         "\n",
@@ -34,7 +34,7 @@
       },
       "outputs": [],
       "source": [
-        "#@title setup\n",
+        "#@title setup (~2 minutes)\n",
         "%%time\n",
         "import os\n",
         "if not os.path.isdir(\"params\"):\n",
@@ -120,7 +120,7 @@
         "id": "UUfKrOzT0gOS"
       },
       "source": [
-        "# fixed backbone design (fixbb)\n",
+        "# fixed backbone design (fixbb) (~2 minutes)\n",
         "For a given protein backbone, generate/design a new sequence that AlphaFold thinks folds into that conformation."
       ]
     },
@@ -213,7 +213,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "# hallucination\n",
+        "# hallucination (~1 minute)\n",
         "For a given length, generate/hallucinate a protein sequence that AlphaFold thinks folds into a well structured protein (high plddt, low pae, many contacts)."
       ],
       "metadata": {


### PR DESCRIPTION
Fixed the typo at the top cys to cyc and added runtimes for the sections.