### PR TITLE
Flash attention

### DIFF
--- a/colabdesign/af/alphafold/model/config.py
+++ b/colabdesign/af/alphafold/model/config.py
@@ -307,7 +307,13 @@ CONFIG = ml_collections.ConfigDict({
             'multimer_mode': False,
             'subbatch_size': 4,
             'use_remat': False,
-            'zero_init': True
+            'zero_init': True,
+            'use_flash_attention': False,
+            'flash': {
+              'num_warps': 2,
+              'block_q': 64,
+              'block_k': 32
+            },
         },
         'heads': {
             'distogram': {
@@ -536,6 +542,12 @@ CONFIG_MULTIMER = ml_collections.ConfigDict({
             'subbatch_size': 4,
             'use_remat': False,
             'zero_init': True,
+            'use_flash_attention': False,
+            'flash': {
+              'num_warps': 2,
+              'block_q': 64,
+              'block_k': 32
+            },
             'use_dgram': False
         },
         'heads': {

--- a/colabdesign/af/alphafold/model/model.py
+++ b/colabdesign/af/alphafold/model/model.py
@@ -62,7 +62,7 @@ class RunModel:
         prev = {'prev_msa_first_row': np.zeros([L,256]),
                 'prev_pair': np.zeros([L,L,128]),
                 'prev_pos': np.zeros([L,37,3])}
-        if self.config.global_config.use_dgram:
+        if self.config.model.global_config.use_dgram:
           prev['prev_dgram'] = np.zeros([L,L,64])
         feat["prev"] = prev
 

--- a/colabdesign/af/alphafold/model/modules.py
+++ b/colabdesign/af/alphafold/model/modules.py
@@ -30,6 +30,8 @@ from colabdesign.af.alphafold.model import utils
 import haiku as hk
 import jax
 import jax.numpy as jnp
+from jax.experimental import pallas as pl
+import jax.lax as lax
 
 from colabdesign.af.alphafold.model.r3 import Rigids, Rots, Vecs
 
@@ -137,7 +139,8 @@ class AlphaFoldIteration(hk.Module):
           representations.update(ret[name].pop('representations'))
 
     for name in ('predicted_lddt', 'predicted_aligned_error'):
-      ret[name] = heads[name](representations, batch)
+      if name in heads:
+        ret[name] = heads[name](representations, batch)
     return ret
 
 class AlphaFold(hk.Module):
@@ -319,15 +322,15 @@ class Attention(hk.Module):
     self.global_config = global_config
     self.output_dim = output_dim
 
-  def __call__(self, q_data, m_data, bias, nonbatched_bias=None):
+  def __call__(self, q_data, m_data, mask, nonbatched_bias=None):
     """Builds Attention module.
 
     Arguments:
       q_data: A tensor of queries, shape [batch_size, N_queries, q_channels].
       m_data: A tensor of memories from which the keys and values are
         projected, shape [batch_size, N_keys, m_channels].
-      bias: A bias for the attention, shape [batch_size, N_queries, N_keys].
-      nonbatched_bias: Shared bias, shape [N_queries, N_keys].
+      mask: A mask for the attention, shape [batch_size or 1, N_heads or 1, N_queries or 1, N_keys].
+      nonbatched_bias: Shared bias, shape [N_heads, N_queries, N_keys].
 
     Returns:
       A float32 tensor of shape [batch_size, N_queries, output_dim].
@@ -341,6 +344,7 @@ class Attention(hk.Module):
     key_dim = key_dim // num_head
     value_dim = value_dim // num_head
 
+    # weight loading
     q_weights = hk.get_parameter(
         'query_w', shape=(q_data.shape[-1], num_head, key_dim),
         dtype=q_data.dtype,
@@ -353,19 +357,6 @@ class Attention(hk.Module):
         'value_w', shape=(m_data.shape[-1], num_head, value_dim),
         dtype=q_data.dtype,
         init=glorot_uniform())
-
-    q = jnp.einsum('bqa,ahc->bqhc', q_data, q_weights) * key_dim**(-0.5)
-    k = jnp.einsum('bka,ahc->bkhc', m_data, k_weights)
-    v = jnp.einsum('bka,ahc->bkhc', m_data, v_weights)
-    logits = jnp.einsum('bqhc,bkhc->bhqk', q, k) + bias
-    if nonbatched_bias is not None:
-      logits += jnp.expand_dims(nonbatched_bias, axis=0)
-
-    # patch for jax > 0.3.25
-    logits = jnp.clip(logits,-1e8,1e8)
-
-    weights = jax.nn.softmax(logits)
-    weighted_avg = jnp.einsum('bhqk,bkhc->bqhc', weights, v)
 
     if self.global_config.zero_init:
       init = hk.initializers.Constant(0.0)
@@ -384,25 +375,245 @@ class Attention(hk.Module):
           dtype=q_data.dtype,
           init=hk.initializers.Constant(1.0))
 
-      gate_values = jnp.einsum('bqc, chv->bqhv', q_data,
-                               gating_weights) + gating_bias
-
-      gate_values = jax.nn.sigmoid(gate_values)
-
-      weighted_avg *= gate_values
-
     o_weights = hk.get_parameter(
         'output_w', shape=(num_head, value_dim, self.output_dim),
         dtype=q_data.dtype,
         init=init)
-    o_bias = hk.get_parameter('output_b', shape=(self.output_dim,),
-                              dtype=q_data.dtype,
-                              init=hk.initializers.Constant(0.0))
+    o_bias = hk.get_parameter(
+        'output_b', shape=(self.output_dim,),
+        dtype=q_data.dtype,
+        init=hk.initializers.Constant(0.0))
+    
+    # pre-kernel
+    if self.config.gating:
+      gate_values = jnp.einsum('bqc, chv->bqhv', q_data,
+                              gating_weights) + gating_bias
+      gate_values = jax.nn.sigmoid(gate_values)
+    else:
+      gate_values = None
+    q = jnp.einsum('bqa,ahc->bqhc', q_data, q_weights) * key_dim**(-0.5)
+    k = jnp.einsum('bka,ahc->bkhc', m_data, k_weights)
+    v = jnp.einsum('bka,ahc->bkhc', m_data, v_weights)
 
+    # kernel
+    q_len, k_len = q.shape[1], k.shape[1]
+    kernel = functools.partial(self.flash_kernel, **self.global_config.flash) if (
+      self.global_config.use_flash_attention and 
+      q_len >= self.global_config.flash.block_q and 
+      k_len >= self.global_config.flash.block_k) else self.reference_kernel
+    weighted_avg = kernel(q, k, v, mask=mask, nonbatched_bias=nonbatched_bias, gate_values=gate_values)
+
+    # post-kernel
     output = jnp.einsum('bqhc,hco->bqo', weighted_avg, o_weights) + o_bias
 
     return output
 
+  @staticmethod
+  def reference_kernel(q, k, v, mask, nonbatched_bias=None, gate_values=None):
+    bias = 1e9*(mask-1.) # move mask to bias so we lower to mha fusion
+    logits = jnp.einsum('bqhc,bkhc->bhqk', q, k) + bias
+    if nonbatched_bias is not None:
+      logits += jnp.expand_dims(nonbatched_bias, axis=0)
+    # patch for jax > 0.3.25
+    logits = jnp.clip(logits,-1e8,1e8)
+    weights = jax.nn.softmax(logits)
+    weighted_avg = jnp.einsum('bhqk,bkhc->bqhc', weights, v)
+    if gate_values is not None:
+      weighted_avg *= gate_values
+    return weighted_avg
+
+  @staticmethod
+  def flash_pallas_kernel(
+    # Input arrays
+    q_ref: jax.Array,
+    k_ref: jax.Array,
+    v_ref: jax.Array,
+    gate_values_ref: jax.Array | None,
+    mask_ref: jax.Array | None,
+    logit_bias_ref: jax.Array | None,
+    # Output arrays
+    o_ref: jax.Array,
+    L_ref: jax.Array | None,
+    # Options
+    block_q: int,
+    block_k: int,
+  ):
+    # convenience functions to match syntax of FlashAttention2 forward pass (Algorithm 1) 
+    _log = jnp.log
+    _exp = jnp.exp
+    _maximum = jnp.maximum
+    _rowmax = lambda x: x.max(axis=-1)
+    _rowsum = lambda x: x.sum(axis=-1)
+    _diag = lambda x: x[:, None]
+    _dot = lambda a, b: pl.dot(a.astype(b.dtype), b) # matches dtype of second element, in dot(p,v) this pushes to use bfloat16
+    _generate_1d_bounds_mask = lambda ref, start, block_size: lax.iota(jnp.int32, block_size)+start*block_size < ref.shape[0] if (ref.shape[0]%block_size!=0) else None
+    # When head_dim < 16 pl.dot is not supported so we pad up
+    _head_dim_mask = lambda ref: jax.lax.iota(jnp.int32, 16)<ref.shape[-1]
+    def _combine_masks(*masks: jax.Array | None):
+      # Combines a set of masks matching the dimension of the tensor to store. None for an all-True array
+      dims = set(range(len(masks)))
+      masks = [jnp.expand_dims(mask, tuple(dims-set({i}))) for i, mask in enumerate(masks) if mask is not None]
+      if (len(masks)==0): return None; # all None case - don't use a mask
+      mask = functools.reduce(lambda x, y: x & y, masks)
+      return mask
+    def _load_mask_kwargs(masks: tuple[jax.Array | None, ...], other=0.):
+      mask = _combine_masks(*masks)
+      return {'mask':mask, 'other':other} if (mask is not None) else {}
+    def _padding_load(ref, slice, dim0_mask=None):
+      return pl.load(ref, (slice, pl.dslice(None)), **_load_mask_kwargs((dim0_mask, None))) if (ref.shape[-1]>=16) else \
+        pl.load(ref, (slice, pl.dslice(0,16)), **_load_mask_kwargs((dim0_mask, _head_dim_mask(ref))))
+    def _padding_store(ref, slice, val, dim0_mask=None):
+      pl.store(ref, (slice, pl.dslice(None)), val, mask=_combine_masks(dim0_mask, None)) if (ref.shape[-1]>=16) else \
+        pl.store(ref, (slice, pl.dslice(0,16)), val, mask=_combine_masks(dim0_mask, _head_dim_mask(ref)))
+
+    # m and l are updated during the kv loop.
+    # o is the buffer where we accumulate the output on sram.
+    m_init = jnp.zeros(block_q, dtype=jnp.float32) - 1e9
+    l_init = jnp.zeros(block_q, dtype=jnp.float32)
+    o_init = jnp.zeros((block_q, max(v_ref.shape[-1], 16)), dtype=jnp.float32)
+
+    # Grid loops over q
+    start_q = pl.program_id(0)
+    q_slice = pl.dslice(start_q * block_q, block_q)
+    q_bounds_mask = _generate_1d_bounds_mask(q_ref, start_q, block_q)
+    q = _padding_load(q_ref, q_slice, q_bounds_mask)
+
+    # Here we only loop over blocks of kv to process entire seq_len, the loop over
+    # blocks of q is carried out by the grid.
+    def body(start_k, carry):
+      o_prev, m_prev, l_prev = carry
+      k_slice = pl.dslice(start_k * block_k, block_k)
+      kv_bounds_mask = _generate_1d_bounds_mask(k_ref, start_k, block_k)
+
+      k = _padding_load(k_ref, k_slice, kv_bounds_mask)
+      v = _padding_load(v_ref, k_slice, kv_bounds_mask)
+      qk = pl.dot(q, k.T)   # (block_q, block_k)
+
+      if (logit_bias_ref is not None):
+        logit_bias = pl.load(logit_bias_ref, (q_slice, k_slice),
+                             **_load_mask_kwargs((q_bounds_mask, kv_bounds_mask)))
+        qk += logit_bias
+
+      if (mask_ref is not None):
+        kv_only_mask = (mask_ref.shape[0]==1)
+        mask = pl.load(mask_ref, (pl.dslice(0,1) if kv_only_mask else q_slice, k_slice), 
+                       **_load_mask_kwargs((None if kv_only_mask else q_bounds_mask, kv_bounds_mask)))
+        qk = jnp.where(mask, qk, -1e9)
+
+      # boundary checks
+      bounds_mask = _combine_masks(q_bounds_mask, kv_bounds_mask)
+      if (bounds_mask is not None):
+        qk = jnp.where(bounds_mask, qk, -1e9)
+      
+      # Mapping of indexing to FlashAttention2 papers notation:
+      # x_{i}^{j-1} = x_prev
+      # x_{i}^{j} = x
+      s = qk
+      rowmax_s = _rowmax(s)
+      m = _maximum(m_prev, rowmax_s)
+      p = _exp(s-_diag(m)) # _diag not present in paper, but is needed
+      l = _exp(m_prev-m)*l_prev + _rowsum(p)
+      o = _diag(_exp(m_prev-m)) * o_prev + _dot(p,v)
+      return o, m, l
+
+    kv_len = k_ref.shape[0]
+    n_blocks = pl.cdiv(kv_len, block_k)
+    o, m, l = lax.fori_loop(0, n_blocks, body, (o_init, m_init, l_init))
+
+    if (gate_values_ref is not None):
+      gate_values = _padding_load(gate_values_ref, q_slice, q_bounds_mask)
+      o *= gate_values
+    
+    o *= _diag(1./l)
+
+    if (L_ref is not None):
+      L = m + _log(l)
+      pl.store(L_ref, (q_slice,), L, mask=q_bounds_mask)
+    # Write output to dram.
+    o = o.astype(o_ref.dtype)
+    _padding_store(o_ref, q_slice, o, q_bounds_mask)
+
+  @classmethod
+  def flash_kernel(
+      cls,
+      q,
+      k,
+      v,
+      gate_values: jnp.ndarray | None = None,
+      mask: jnp.ndarray | None = None, 
+      nonbatched_bias: jnp.ndarray | None = None,
+      return_residual: bool = False,
+      block_q: int = 32,
+      block_k: int = 32,
+      num_warps: int | None = 2,
+      num_stages: int = 2,
+      grid: tuple[int, ...] | None = None,
+      interpret: bool = False,
+      debug: bool = False,
+  ):
+    if (mask is not None):
+      mask = mask.astype(jnp.bool_)
+    batch_size, q_len, num_heads, qk_head_dim = q.shape
+    _, kv_len, _, _ = k.shape
+    _, _, _, v_head_dim = v.shape
+
+    block_q = min(block_q, q_len)
+    block_k = min(block_k, kv_len)
+
+    if grid is None:
+      grid = (pl.cdiv(q_len, block_q), batch_size, num_heads)
+    
+    kernel = functools.partial(cls.flash_pallas_kernel,
+                              block_q=block_q,
+                              block_k=block_k)
+    out_shape = (
+        jax.ShapeDtypeStruct(shape=(batch_size, q_len, num_heads, v_head_dim), dtype=q.dtype), # out
+        jax.ShapeDtypeStruct(shape=(batch_size, num_heads, q_len), dtype=jnp.float32) if return_residual else None, # L
+    )
+    in_specs = (
+        # j,k in grid parallelise over batch and head
+        pl.BlockSpec(
+            lambda _, j, k: (j, 0, k, 0), (None, q_len, None, qk_head_dim) # bqh(c_qk)
+        ),
+        pl.BlockSpec(
+            lambda _, j, k: (j, 0, k, 0), (None, kv_len, None, qk_head_dim) # bkh(c_qk)
+        ),
+        pl.BlockSpec(
+            lambda _, j, k: (j, 0, k, 0), (None, kv_len, None, v_head_dim) # bkh(c_v)
+        ),
+    )
+    in_specs+= (None,) if (gate_values is None) else (
+      pl.BlockSpec(lambda _, j, k: (j, 0, k, 0), (None, q_len, None, v_head_dim)), # bqh(c_v)
+    )
+    # mask might be (b or 1, h or 1, q or 1, k) in shape, we deal with b and/or h broadcast here. 
+    # we deal with q broadcast in the kernel
+    in_specs+= (None,) if (mask is None) else (
+      pl.BlockSpec(lambda _, j, k: (
+        j if mask.shape[0]!=1 else 0,
+        k if mask.shape[1]!=1 else 0,
+        0, 0), (None,  None,)+mask.shape[2:4]), # bhqk
+    )
+    in_specs+= (None,) if (nonbatched_bias is None) else (
+      pl.BlockSpec(lambda _, j, k: (k, 0, 0), (None, q_len, kv_len)), # hqk
+    )
+    
+    out, L = pl.pallas_call(
+        kernel,
+        grid=grid,
+        in_specs=in_specs,
+        out_specs=(
+            pl.BlockSpec(lambda _, j, k: (j, 0, k, 0), (None, q_len, None, v_head_dim)), # bqh(c_v)
+            pl.BlockSpec(lambda _, j, k: (j, k, 0), (None, None, q_len)) if return_residual else None, # bhq
+        ),
+        compiler_params=dict(
+            triton=dict(num_warps=num_warps, num_stages=num_stages)
+        ),
+        out_shape=out_shape,
+        debug=debug,
+        interpret=interpret,
+        name="flash_attention",
+    )(q, k, v, gate_values, mask, nonbatched_bias)
+    return out
 
 class GlobalAttention(hk.Module):
   """Global attention.
@@ -533,8 +744,8 @@ class MSARowAttentionWithPairBias(hk.Module):
     assert len(msa_mask.shape) == 2
     assert c.orientation == 'per_row'
 
-    bias = (1e9 * (msa_mask - 1.))[:, None, None, :]
-    assert len(bias.shape) == 4
+    mask = msa_mask[:, None, None, :]
+    assert len(mask.shape) == 4
 
     msa_act = common_modules.LayerNorm(
         axis=[-1], create_scale=True, create_offset=True, name='query_norm')(
@@ -560,7 +771,7 @@ class MSARowAttentionWithPairBias(hk.Module):
     msa_act = mapping.inference_subbatch(
         attn_mod,
         self.global_config.subbatch_size,
-        batched_args=[msa_act, msa_act, bias],
+        batched_args=[msa_act, msa_act, mask],
         nonbatched_args=[nonbatched_bias],
         low_memory=self.global_config.subbatch_size is not None)
 
@@ -599,8 +810,8 @@ class MSAColumnAttention(hk.Module):
     msa_act = jnp.swapaxes(msa_act, -2, -3)
     msa_mask = jnp.swapaxes(msa_mask, -1, -2)
 
-    bias = (1e9 * (msa_mask - 1.))[:, None, None, :]
-    assert len(bias.shape) == 4
+    mask = msa_mask[:, None, None, :]
+    assert len(mask.shape) == 4
 
     msa_act = common_modules.LayerNorm(
         axis=[-1], create_scale=True, create_offset=True, name='query_norm')(
@@ -611,7 +822,7 @@ class MSAColumnAttention(hk.Module):
     msa_act = mapping.inference_subbatch(
         attn_mod,
         self.global_config.subbatch_size,
-        batched_args=[msa_act, msa_act, bias],
+        batched_args=[msa_act, msa_act, mask],
         nonbatched_args=[],
         low_memory=self.global_config.subbatch_size is not None)
 
@@ -708,8 +919,8 @@ class TriangleAttention(hk.Module):
       pair_act = jnp.swapaxes(pair_act, -2, -3)
       pair_mask = jnp.swapaxes(pair_mask, -1, -2)
 
-    bias = (1e9 * (pair_mask - 1.))[:, None, None, :]
-    assert len(bias.shape) == 4
+    mask = pair_mask[:, None, None, :]
+    assert len(mask.shape) == 4
 
     pair_act = common_modules.LayerNorm(
         axis=[-1], create_scale=True, create_offset=True, name='query_norm')(
@@ -728,7 +939,7 @@ class TriangleAttention(hk.Module):
     pair_act = mapping.inference_subbatch(
         attn_mod,
         self.global_config.subbatch_size,
-        batched_args=[pair_act, pair_act, bias],
+        batched_args=[pair_act, pair_act, mask],
         nonbatched_args=[nonbatched_bias],
         low_memory=self.global_config.subbatch_size is not None)
 
@@ -1758,11 +1969,11 @@ class TemplateEmbedding(hk.Module):
         jnp.transpose(template_pair_representation, [1, 2, 0, 3]),
         [num_res * num_res, num_templates, num_channels])
 
-    bias = (1e9 * (template_mask[None, None, None, :] - 1.))
+    mask = template_mask[None, None, None, :]
 
     template_pointwise_attention_module = Attention(
         self.config.attention, self.global_config, query_num_channels)
-    nonbatched_args = [bias]
+    nonbatched_args = [mask]
     batched_args = [flat_query, flat_templates]
 
     embedding = mapping.inference_subbatch(


### PR DESCRIPTION
Implements FlashAttention similarly to https://github.com/google-deepmind/alphafold/pull/931 

For a 759 residue protein and model_5 this improves runtime 2.2x on an L4 (37.3 $\rightarrow$ 16.9 seconds [with minibatching of 256 for non-flash attention to avoid OOM])

Here's a [colab](https://colab.research.google.com/drive/1_jQO85diOEgObO2V3xQpAwhgdj7m70p9?usp=sharing) link showing runtime improvement and no significant change in prediction output by visual inspection. I didn't want to rerun all the input prep so I've used a colab with alphafold input preparation and done fixes for colabdesign.

### Notes
Key variations from a reference flash attention kernel are:
- Attention logit biasing supported
- Gating supported
- Some heads have only 8 channels, they’re padded up to 16 within kernel (this is a requirement of pl.dot, we still see performance improvement relative to non-flash attn and keeps overall AlphaFold2 linear in memory requirements)
- Broadcasted masks in batch, q and head dimensions supported (they’re often size 1 and implicitly broadcasted in AlphaFold2 einsums)

There's guards against kernel being called for short sequence lengths less than block sizes specified in q and k which exits to reference kernel.

### Comments
- I think the runtime improvement is benefitting from the triangular fusion you've previously implemented, as on an A100 I saw with flash attention and bfloat16 that starts to be significant.
- I haven't done correctness/speed checks with multimer models or models using templates. If you have a test suite to do that, that'd be wonderful.
- When you said ['fused attention'](https://github.com/google-deepmind/alphafold/pull/931#issuecomment-2067760549) you meant shifting the mask to a bias so XLA lowers it to a fused kernel, right? I've moved that mask $\rightarrow$ bias conversion into the Attention module itself and kept it in the reference_kernel (so now reference_kernel differs from the one in [google-deepmind/alphafold#931](https://github.com/google-deepmind/alphafold/pull/931)). So with `use_flash_attention=False` I haven't changed behaviour: here's a [colab](https://colab.research.google.com/drive/1oqy7T_ZRfJNqnuI9tdxHnvGYxPBMz0qb?usp=sharing) showing same 37.3s runtime from the main branch.
- fix for use_dgram which seemed to access the wrong config keys 
- fix for models not containing pae head